### PR TITLE
Add explicit return type to avoid deprecation warnings on Symfony 6.2

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('pixelopen_cloudflare_turnstile');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Type/TurnstileType.php
+++ b/src/Type/TurnstileType.php
@@ -35,12 +35,12 @@ class TurnstileType extends AbstractType
         $view->vars['key'] = $this->key;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'turnstile';
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return TextType::class;
     }


### PR DESCRIPTION
This PR fixes the deprecation warning on Symfony 6.2 by adding explicit return types to `getBlockPrefix()` and `getParent()`.

> Method "Symfony\Component\Form\FormTypeInterface::getParent()" might add "?string" as a native return type declaration in the future. Do the same in implementation "PixelOpen\CloudflareTurnstileBundle\Type\TurnstileType" now to avoid errors or add an explicit `@return` annotation to suppress this message.

> Method "Symfony\Component\Form\FormTypeInterface::getBlockPrefix()" might add "string" as a native return type declaration in the future. Do the same in implementation "PixelOpen\CloudflareTurnstileBundle\Type\TurnstileType" now to avoid errors or add an explicit `@return` annotation to suppress this message.

> Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "PixelOpen\CloudflareTurnstileBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.