### PR TITLE
Prefer defer to async to improve page speed

### DIFF
--- a/src/Resources/views/fields.html.twig
+++ b/src/Resources/views/fields.html.twig
@@ -1,5 +1,5 @@
 {% block turnstile_widget %}
-    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>
     {% set attributes = attr | merge({class: (attr.class|default('cf-turnstile'))}) %}
 
     <div class="cf-turnstile"


### PR DESCRIPTION
I think that currently by setting both options, async is prefered.
So just keep defer as it's the wanted behavior I think to avoid this kind of pagespeed warning:

![image](https://github.com/Pixel-Open/cloudflare-turnstile-bundle/assets/5782198/f50ec33e-aeaa-48d2-8769-c79070bc2227)

Source:

![image](https://github.com/Pixel-Open/cloudflare-turnstile-bundle/assets/5782198/d867803c-d73d-45a2-a2e9-1be7514ab218)


https://pagespeedchecklist.com/async-and-defer