### PR TITLE
Fix TreeBuilder name

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder('pixelopen_cloudflare_turnstile');
+        $treeBuilder = new TreeBuilder('pixel_open_cloudflare_turnstile');
         $rootNode = $treeBuilder->getRootNode();
 
         $rootNode


### PR DESCRIPTION
I was using PHP config and Symfony generated wrong config class name for this bundle

```bash
 There is no extension able to load the configuration for "Symfony\Config\PixelopenCloudflareTurnstileConfig". Looked for namespace "pixelopen_cloudflare_turnstile",
  found "framework", "doctrine", "...", "pixel_open_cloudflare_turnstile".
```

I've tested this changes and doesn't change the behavior for YAML config

## how to reproduce

```sh
composer require pixelopen/cloudflare-turnstile-bundle
rm config/packages/pixel_open_cloudflare_turnstile.yaml
```

Symfony will create a config builder class in `var/cache/dev/Symfony/Config/PixelopenCloudflareTurnstileConfig.php`

create PHP config 


```php
<?PHP

// config/packages/pixel_open_cloudflare_turnstile.php

<?php

use Symfony\Config\PixelopenCloudflareTurnstileConfig;

use function Symfony\Component\DependencyInjection\Loader\Configurator\env;

return static function(PixelopenCloudflareTurnstileConfig $pixelopenCloudflareTurnstile): void {
    $pixelopenCloudflareTurnstile
        ->key(env('TURNSTILE_KEY'))
        ->secret(env('TURNSTILE_SECRET'));
};
```

this patch will make Symfony create `var/cache/dev/Symfony/Config/PixelOpenCloudflareTurnstileConfig.php` (with upper-case O) config builder class and point to the correct bundle