### PR TITLE
fix deprecation from Extension class

### DIFF
--- a/src/DependencyInjection/PixelOpenCloudflareTurnstileExtension.php
+++ b/src/DependencyInjection/PixelOpenCloudflareTurnstileExtension.php
@@ -6,8 +6,8 @@ namespace PixelOpen\CloudflareTurnstileBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration.


### PR DESCRIPTION
```
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be
deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further
notice. You should not use it from
"PixelOpen\CloudflareTurnstileBundle\DependencyInjection\PixelOpenCloudflareTurnstileExtension".
```